### PR TITLE
fix(vATIS): Missing commas added

### DIFF
--- a/EKDK/Plugins/vATIS/vATIS_EKCH.json
+++ b/EKDK/Plugins/vATIS/vATIS_EKCH.json
@@ -2285,7 +2285,7 @@
           "text": "DELIVERY FREQ 119.905 ACTIVE",
           "ordinal": 1,
           "enabled": true
-        }
+        },
         {
           "text": "ON FIRST CONTACT WITH KASTRUP APRON,\r\nADVISE IF UNABLE TO PERFORM PUSHBACK\r\nTO A RELEASE POINT",
           "ordinal": 2,
@@ -2295,7 +2295,7 @@
           "text": "STATE IF REQUESTING DEICING",
           "ordinal": 3,
           "enabled": true
-        }
+        },
         {
           "text": "AFTER PASSING 1000FT, CONTACT KASTRUP DEPARTURE\r\nUSING FREQ STATED ON CHARTS",
           "ordinal": 4,

--- a/EKDK/Plugins/vATIS/vATIS_EKDK.json
+++ b/EKDK/Plugins/vATIS/vATIS_EKDK.json
@@ -13405,7 +13405,7 @@
           "text": "DELIVERY FREQ 119.905 ACTIVE",
           "ordinal": 1,
           "enabled": true
-        }
+        },
         {
           "text": "ON FIRST CONTACT WITH KASTRUP APRON,\r\nADVISE IF UNABLE TO PERFORM PUSHBACK\r\nTO A RELEASE POINT",
           "ordinal": 2,
@@ -13415,7 +13415,7 @@
           "text": "STATE IF REQUESTING DEICING",
           "ordinal": 3,
           "enabled": true
-        }
+        },
         {
           "text": "AFTER PASSING 1000FT, CONTACT KASTRUP DEPARTURE\r\nUSING FREQ STATED ON CHARTS",
           "ordinal": 4,


### PR DESCRIPTION
Added missing commas in vATIS profiles causing them to not being able to be used.